### PR TITLE
username and passward pass to confirm using navigate.state

### DIFF
--- a/src/frontend/src/features/auth/routes/SignUp.tsx
+++ b/src/frontend/src/features/auth/routes/SignUp.tsx
@@ -6,7 +6,7 @@ import { useAuth } from '@/lib/auth/cognito-auth'
 import { Input } from '../components'
 
 export const SignUp = () => {
-  const { signUp } = useAuth() // useAuth フックから signUp 関数を取得
+  const { signUp } = useAuth()
   const [username, setUsername] = useState('')
   const [password, setPassword] = useState('')
   const [error, setError] = useState('')
@@ -23,7 +23,7 @@ export const SignUp = () => {
     } else {
       setError('')
       alert('登録成功！確認コードを入力してアカウントを有効化してください。')
-      navigate('/auth/confirm')
+      navigate('/auth/confirm', { state: { username, password } }) // ここで状態を渡す
     }
   }
 


### PR DESCRIPTION
## 概要

検証コードを入力する画面でメールアドレスとパスワードの再入力をしなくて済むようにすること

## 変更点

このセクションでは、具体的な変更点や修正箇所を箇条書きでリストアップしてください。

- SignUp.tsxにてnavigate.stateにメールアドレスとパスワードを格納しました。
- ConfirmSignUp.tsxにてメールアドレスとパスワードを取得するように変更しました。
- ConfirmSignUp.tsx にて入力フォームを検証コードのみに変更しました。

## 影響範囲

ローカルに一時的にユーザネームとパスワードが保存されるので一定のセキュリティリスクが発生する。

## テスト

このセクションでは、この PR に関連するテストケースやテスト方法を記載してください。

- テストケース 1
実際にアカウント新規登録を実施
0. 開発環境のユーザプールにユーザが存在する場合は事前に削除する
1. 新規登録を実施。
2. 検証画面にて検証コードの入力フォームのみ存在している事、検証コード入力後に登録に成功する事を確認する

## 関連 Issue


- 関連 Issue: #199 
- 関連 Issue: #200 
