### PR TITLE
fix: Remove unused import in change-password-form component


### DIFF
--- a/src/frontend/src/features/setting/components/change-password-form.tsx
+++ b/src/frontend/src/features/setting/components/change-password-form.tsx
@@ -1,5 +1,5 @@
 import { Button } from '@/components/ui/button'
-import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from '@/components/ui/form/form'
+import { Form, FormControl, FormField, FormItem, FormMessage } from '@/components/ui/form/form'
 import { Input } from '@/components/ui/form/input'
 import { useAuth } from '@/lib/auth/cognito-auth'
 import { z } from 'zod'


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Removed an unused import `FormLabel` from the `change-password-form.tsx` file to clean up the code.
- This change helps in maintaining a cleaner and more efficient codebase by eliminating unnecessary imports.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>change-password-form.tsx</strong><dd><code>Removed unused import in change-password-form component</code>&nbsp; &nbsp; </dd></summary>
<hr>

src/frontend/src/features/setting/components/change-password-form.tsx

- Removed an unused import `FormLabel` from the file.



</details>


  </td>
  <td><a href="https://github.com/Kota8102/diary-app/pull/254/files#diff-d173ef82a9bae7298d8d6ed84753d3e3d2d73b3c7db64cff00bbb2363e299ccf">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information