### PR TITLE
feat: 花束作成機能のロギングと週番号取得の追加


### DIFF
--- a/src/backend/lambda/bouquet_create/bouquet_create.py
+++ b/src/backend/lambda/bouquet_create/bouquet_create.py
@@ -842,7 +842,7 @@ class MkBouquet(DecideFlowerPos):
         花の画像を設定する。
         """
         for flower_id in self.original_flowers:
-            flower_image = self.load_image(f"single_flowers/{flower_id}.png")
+            flower_image = self.load_image(f"flowers/{flower_id}.png")
             self.flower_images.append(flower_image)
 
     def load_image(self, key):


### PR DESCRIPTION
### **User description**
## 概要

花束作成時にモジュールインポートエラーが発生していたため、修正

## 変更点

このセクションでは、具体的な変更点や修正箇所を箇条書きでリストアップしてください。

- モジュールのインポートを修正
- year_week の指定を関数で実行するように変更

## 影響範囲

- Lambda 関数内で完結するため特になし

## テスト

このセクションでは、この PR に関連するテストケースやテスト方法を記載してください。

- pytest を実行

## 関連 Issue

- 関連 Issue: #273


___

### **PR Type**
enhancement


___

### **Description**
- ロギング機能を追加

- 現在の年と週番号を取得する関数を追加

- 花束記録の保存時に週番号を使用

- 不要な変数を削除


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>bouquet_create.py</strong><dd><code>花束作成機能の改善</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/backend/lambda/bouquet_create/bouquet_create.py

- ロギングのインポートを追加
- 現在の年と週番号を取得する関数を追加
- 花束記録の保存時に週番号を使用
- 不要な変数を削除


</details>


  </td>
  <td><a href="https://github.com/Kota8102/diary-app/pull/274/files#diff-e201a05062a388488f791d8cfab469ef81b1197892abcc1a5bd37b9aedcaa2fc">+26/-7</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>