### PR TITLE
fix: 花束作成ボタンが表示されないバグを修正


### DIFF
--- a/src/backend/lambda/get_diary_data/get_diary_data.py
+++ b/src/backend/lambda/get_diary_data/get_diary_data.py
@@ -175,9 +175,11 @@ def check_bouquet_created(user_id: str, year_week: str) -> bool:
     bouquet_table_name = os.getenv("BOUQUET_TABLE_NAME")
     bouquet_table = dynamodb.Table(bouquet_table_name)
     try:
-        response = bouquet_table.get_item(Key={"user_id": user_id, "year_week": year_week})
+        response = bouquet_table.get_item(
+            Key={"user_id": user_id, "year_week": year_week}
+        )
         print(f"response: {response}")
-        return 'Item' in response
+        return "Item" in response
     except ClientError:
         return False
 

--- a/src/backend/lambda/get_diary_data/get_diary_data.py
+++ b/src/backend/lambda/get_diary_data/get_diary_data.py
@@ -178,7 +178,7 @@ def check_bouquet_created(user_id: str, year_week: str) -> bool:
         response = bouquet_table.get_item(
             Key={"user_id": user_id, "year_week": year_week}
         )
-        print(f"response: {response}")
+        # logging.debug(f"response: {response}")
         return "Item" in response
     except ClientError:
         return False

--- a/src/backend/lambda/get_diary_data/get_diary_data.py
+++ b/src/backend/lambda/get_diary_data/get_diary_data.py
@@ -175,8 +175,9 @@ def check_bouquet_created(user_id: str, year_week: str) -> bool:
     bouquet_table_name = os.getenv("BOUQUET_TABLE_NAME")
     bouquet_table = dynamodb.Table(bouquet_table_name)
     try:
-        bouquet_table.get_item(Key={"user_id": user_id, "year_week": f"{year_week}"})
-        return True
+        response = bouquet_table.get_item(Key={"user_id": user_id, "year_week": year_week})
+        print(f"response: {response}")
+        return 'Item' in response
     except ClientError:
         return False
 


### PR DESCRIPTION
### **User description**
## 概要

花束の作成ボタンが表示されなかったので、表示されるように修正をした。

## 変更点

- すでに花束を作っているかどうかを判断する箇所において、常に true となるようになっていたので、DynamoDB の記録の有無を元に判断するように変更。

## 影響範囲

特になし

## テスト

特になし

## 関連 Issue

- 関連 Issue: #287


___

### **PR Type**
Bug fix


___

### **Description**
- 花束作成ボタン表示のバグ修正

- DynamoDBの記録に基づく判断に変更


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>get_diary_data.py</strong><dd><code>花束作成判断ロジックの修正</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/backend/lambda/get_diary_data/get_diary_data.py

- 花束作成の判断ロジックを修正
- DynamoDBからのレスポンスを確認


</details>


  </td>
  <td><a href="https://github.com/Kota8102/diary-app/pull/288/files#diff-9f365c088d2b3c27ba98ee698e7c46940d00da6844dc8a2794f04d0c979dd6a2">+5/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>